### PR TITLE
Change so that the ESASky widget always starts in science mode

### DIFF
--- a/src/pyesasky.ts
+++ b/src/pyesasky.ts
@@ -45,7 +45,7 @@ export class ESASkyJSView extends DOMWidgetView {
     iframe.setAttribute("width", "100%");
     iframe.setAttribute("height", "800px");
     iframe.setAttribute("style", "border: none");
-    iframe.setAttribute("src", this.apiAddr + "?hide_welcome=true&hide_sci_switch=true&hide_banner_info=true");
+    iframe.setAttribute("src", this.apiAddr + "?hide_welcome=true&hide_sci_switch=true&sci=true&hide_banner_info=true");
     iframe.onload = function() {
       // Send init message so that esasky know of the pyesasky client and may initiate communication
       iframe.contentWindow.postMessage({'event': 'initTest', 'origin': 'pyesasky'}, self.apiAddr)


### PR DESCRIPTION
Sometimes cookies from an external session could make the ESASky widget start in explorer-mode with no way of switching back to science mode. I've added an URL-parameter to force the widget to always start in science mode.